### PR TITLE
Trim last slash from folder

### DIFF
--- a/Deploy-SSRSProject/Deploy-SSRSProject.ps1
+++ b/Deploy-SSRSProject/Deploy-SSRSProject.ps1
@@ -62,6 +62,10 @@ function Normalize-SSRSFolder (
 	if (-not $Folder.StartsWith('/')) {
 		$Folder = '/' + $Folder
 	}
+	
+	if($Folder.EndsWith('/')) {
+		$Folder = $Folder.Substring(0, $Folder.Length -1)
+	}
 
 	return $Folder
 }


### PR DESCRIPTION
SSRS 2008 R2 crashes when a the last character is a slash in the folder structure.
