### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The current lack of license is causing ambiguity around reuse of this very useful module created by the below generous people out in the open.

It started off life as just a script thrown up on the gist site, but has grown to something much more than that thanks to the efforts of the people below. Without a license this project has an uncertain future and makes use of it problematic in some organisations; so it would be great to get it properly licenced.

Merging this will require the approval of the following who have all written parts of this project's code:

* [x] @carpnick 
* [x] @ChrisMissal 
* [x] @Jonesie 
* [x] @jstangroome 
* [x] @MisterY 
* [x] @prebenh

Please would you all kindly use the comments to indicate your approval to license your contributions to this project under the MIT licence. (edit - and/or the approved button)

Many thanks.

Tim