### PR TITLE
Replaces Write-Host with Write-Verbose

### DIFF
--- a/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
+++ b/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
@@ -197,5 +197,5 @@
 			New-SSRSReport -Proxy $Proxy -RdlPath $CompiledRdlPath
 		}
 
-	Write-host "Completed."
+	Write-Verbose "Completed."
 }


### PR DESCRIPTION
Write-Host is harmful, and also not supported in VSTS automation tasks.