### PR TITLE
Fix Error When Only One Item Exists in ItemGroup

### DIFF
--- a/ssrs-powershell-deploy/SSRS/Get-SSRSProjectConfiguration.ps1
+++ b/ssrs-powershell-deploy/SSRS/Get-SSRSProjectConfiguration.ps1
@@ -41,15 +41,16 @@
 
 
 	$OverwriteDataSources = $false
-	if ($Config.SelectSingleNode('OverwriteDataSources')) {
+	if ($Config.OverwriteDataSources -eq "True") {
 		$OverwriteDataSources = [Convert]::ToBoolean($Config.OverwriteDataSources)
 	}
 	
 	$OverwriteDatasets = $false
-	if ($Config.SelectSingleNode('OverwriteDatasets')) {
+	if ($Config.OverwriteDatasets -eq "True") {
 		$OverwriteDatasets = [Convert]::ToBoolean($Config.OverwriteDatasets)
 	}
 	
+
 
 	return New-Object -TypeName PSObject -Property @{
 		ServerUrl = $Config.TargetServerUrl

--- a/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
+++ b/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
@@ -139,7 +139,7 @@
 	New-SSRSFolder -Proxy $Proxy -Name $DataSourceFolder
 	New-SSRSFolder -Proxy $Proxy -Name $DataSetFolder
 
-	$DataSourceArray = [array] $Project.Project.ItemGroup[0].Report
+	$DataSourceArray = [array] $Project.Project.ItemGroup[0].DataSource
 	
 	$DataSourcePaths = @{}
 	for($i = 0; $i -lt $DataSourceArray.Count; $i++) {

--- a/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
+++ b/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
@@ -138,8 +138,13 @@
 	New-SSRSFolder -Proxy $Proxy -Name $Folder
 	New-SSRSFolder -Proxy $Proxy -Name $DataSourceFolder
 	New-SSRSFolder -Proxy $Proxy -Name $DataSetFolder
+	
+	switch ($Project.Project.ItemGroup.Length) {
+		"3" {$DataSourceIndex=1;$reportIndex=2}
+		"2" {$DataSourceIndex=0;$reportIndex=1}
+	}
 
-	$DataSourceArray = [array] $Project.Project.ItemGroup[0].DataSource
+	$DataSourceArray = [array] $Project.Project.ItemGroup[$DataSourceIndex].DataSource
 	
 	$DataSourcePaths = @{}
 	for($i = 0; $i -lt $DataSourceArray.Count; $i++) {
@@ -150,9 +155,9 @@
 	}
 
 	$DataSetPaths = @{}
-	$Project.SelectNodes('Project/DataSets/ProjectItem') |
+	$Project.Project.ItemGroup.selectNodes("*") | Where-Object {$_.Include -like "*.rsd"} |
 		ForEach-Object {
-			$RsdPath = $ProjectRoot | Join-Path -ChildPath $_.FullPath
+			$RsdPath = $ProjectRoot | Join-Path -ChildPath $_.Include
 			$DataSet = New-SSRSDataSet -Proxy $Proxy -RsdPath $RsdPath -Folder $DataSetFolder -DataSourcePaths $DataSourcePaths -Overwrite $OverwriteDatasets
 			if(-not $DataSetPaths.Contains($DataSet.Name))
 			{
@@ -160,7 +165,7 @@
 			}
 		}
 	
-	$ReportsArray = [array] $Project.Project.ItemGroup[1].Report
+	$ReportsArray = [array] $Project.Project.ItemGroup[$reportIndex].Report
 
 	for($i = 0; $i -lt $ReportsArray.Count; $i++) {
 

--- a/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
+++ b/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
@@ -140,7 +140,7 @@
 	New-SSRSFolder -Proxy $Proxy -Name $DataSetFolder
 
 	$DataSourcePaths = @{}
-	for($i = 0; $i -lt $Project.Project.ItemGroup[0].DataSource.Count; $i++) {
+	for($i = 0; $i -lt ([array]$Project.Project.ItemGroup[0].DataSource).Count; $i++) {
 		$RdsPath = $ProjectRoot | Join-Path -ChildPath $Project.Project.ItemGroup[0].DataSource[$i].Include
 
 		$DataSource = New-SSRSDataSource -Proxy $Proxy -RdsPath $RdsPath -Folder $DataSourceFolder -Overwrite $OverwriteDataSources
@@ -157,14 +157,16 @@
 				$DataSetPaths.Add($DataSet.Name, $DataSet.Path)
 			}
 		}
+	
+	$ReportsArray = [array] $Project.Project.ItemGroup[1].Report
 
-	for($i = 0; $i -lt $Project.Project.ItemGroup[1].Report.Count; $i++) {
+	for($i = 0; $i -lt $ReportsArray.Count; $i++) {
 
-            $extension = $Project.Project.ItemGroup[1].Report[$i].Include.Substring($Project.Project.ItemGroup[1].Report[$i].Include.length - 3 , 3)
+            $extension = $ReportsArray[$i].Include.Substring($ReportsArray[$i].Include.length - 3 , 3)
 
 			if(ImageExtensionValid -ext $extension){
 
-				$PathImage = $ProjectRoot | Join-Path -ChildPath $Project.Project.ItemGroup[1].Report[$i].Include
+				$PathImage = $ProjectRoot | Join-Path -ChildPath $ReportsArray[$i].Include
 				$RawDefinition = Get-Content -Encoding Byte -Path $PathImage
 
 				$DescProp = New-Object -TypeName SSRS.ReportingService2010.Property
@@ -179,17 +181,17 @@
 
 				$Properties = @($DescProp, $HiddenProp, $MimeProp)
 
-				$Name = $Project.Project.ItemGroup[1].Report[$i].Include
+				$Name = $ReportsArray[$i].Include
 				Write-Verbose "Creating resource $Name"
 				$warnings = $null
-				$Results = $Proxy.CreateCatalogItem("Resource", $Project.Project.ItemGroup[1].Report[$i].Include, $Folder, $true, $RawDefinition, $Properties, [ref]$warnings)
+				$Results = $Proxy.CreateCatalogItem("Resource", $ReportsArray[$i].Include, $Folder, $true, $RawDefinition, $Properties, [ref]$warnings)
 			}
 		}
 
-	for($i = 0; $i -lt $Project.Project.ItemGroup[1].Report.Count; $i++) {
-        if($Project.Project.ItemGroup[1].Report[$i].Include.EndsWith('.rdl')){
-			$CompiledRdlPath = $ProjectRoot | Join-Path -ChildPath $OutputPath | join-path -ChildPath $Project.Project.ItemGroup[1].Report[$i].Include
-			New-SSRSReport -Proxy $Proxy -RdlPath $CompiledRdlPath -RdlName $Project.Project.ItemGroup[1].Report[$i].Include
+	for($i = 0; $i -lt $ReportsArray.Count; $i++) {
+        if($ReportsArray[$i].Include.EndsWith('.rdl')){
+			$CompiledRdlPath = $ProjectRoot | Join-Path -ChildPath $OutputPath | join-path -ChildPath $ReportsArray[$i].Include
+			New-SSRSReport -Proxy $Proxy -RdlPath $CompiledRdlPath -RdlName $ReportsArray[$i].Include
         }
 	}
 

--- a/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
+++ b/ssrs-powershell-deploy/SSRS/Publish-SSRSProject.ps1
@@ -139,9 +139,11 @@
 	New-SSRSFolder -Proxy $Proxy -Name $DataSourceFolder
 	New-SSRSFolder -Proxy $Proxy -Name $DataSetFolder
 
+	$DataSourceArray = [array] $Project.Project.ItemGroup[0].Report
+	
 	$DataSourcePaths = @{}
-	for($i = 0; $i -lt ([array]$Project.Project.ItemGroup[0].DataSource).Count; $i++) {
-		$RdsPath = $ProjectRoot | Join-Path -ChildPath $Project.Project.ItemGroup[0].DataSource[$i].Include
+	for($i = 0; $i -lt $DataSourceArray.Count; $i++) {
+		$RdsPath = $ProjectRoot | Join-Path -ChildPath $DataSourceArray[$i].Include
 
 		$DataSource = New-SSRSDataSource -Proxy $Proxy -RdsPath $RdsPath -Folder $DataSourceFolder -Overwrite $OverwriteDataSources
 		$DataSourcePaths.Add($DataSource.Name, $DataSource.Path)


### PR DESCRIPTION
The xml parser treats the child nodes differently while converting to PS objects. It casts it to single XML Element when there is only one child node but an array of objects if more. Hence, it will fail with "no Count property" error when the itemgroup is accessed as `$Project.Project.ItemGroup[0].DataSource.Count` or `$Project.Project.ItemGroup[1].Report.Count` when there's only one dataSource/report. 

The fix simply convert it into array explicitly beforehand and assign with variable other than accessing directly from $project. 






